### PR TITLE
Use installed yamllint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: ⤵️ Check out configuration from GitHub
         uses: actions/checkout@v4.2.2
       - name: 🚀 Run yamllint
-        uses: frenck/action-yamllint@v1.5.0
+        run: yamllint
 
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: ⤵️ Check out configuration from GitHub
         uses: actions/checkout@v4.2.2
       - name: 🚀 Run yamllint
-        run: yamllint
+        run: yamllint .
 
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - CI workflow simplified: YAML linting now runs via the linter CLI instead of a third‑party action.
  - Relies on the linter being available on the runner PATH; failure reporting now follows the CLI exit status.
  - Slightly faster and more transparent CI; no functional or UI changes for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->